### PR TITLE
Admin updates to donation flow

### DIFF
--- a/classes/class-minnpost-membership-admin.php
+++ b/classes/class-minnpost-membership-admin.php
@@ -709,6 +709,21 @@ class MinnPost_Membership_Admin {
 				),
 			);
 
+			$frequency_options = $this->member_levels->get_frequency_options();
+			if ( ! empty( $frequency_options ) ) {
+				foreach ( $frequency_options as $key => $option ) {
+					$settings[ $this_section . '_suggested_amounts_' . $option['id'] ] = array(
+						'title'    => sprintf( __( '%1$s suggested amounts', 'minnpost-membership' ), ucwords( $option['text'] ) ),
+						'callback' => array( $this, 'display_suggested_amounts' ),
+						'page'     => $this_section,
+						'section'  => $this_section,
+						'args'     => array(
+							'desc'        => ''
+						),
+					);
+				}
+			}
+
 			$settings[ $this_section . '_pre_form_text' ] = array(
 				'title'    => __( 'Pre form text', 'minnpost-membership' ),
 				'callback' => $callbacks['text'],
@@ -3340,6 +3355,29 @@ class MinnPost_Membership_Admin {
 			);
 		}
 
+	}
+
+	public function display_suggested_amounts( $args ) {
+		$desc      = $args['desc'];
+		$id        = $args['label_for'];
+		$name      = $args['name'];
+		$value     = get_option( $id, '' );
+		if ( '' === $value && isset( $args['default'] ) && '' !== $args['default'] ) {
+			$value = $args['default'];
+		}
+
+		foreach ( range( 0, 3 ) as $i ) {
+		    printf( '<div>' );
+			printf( '<input type="text" name="%1$s" value="%2$s" size="5">',
+				esc_attr( $name . '[' . $i . '][amount]' ),
+				esc_attr( $value[$i]['amount'] )
+			);
+			printf( '<input type="text" name="%1$s" value="%2$s" size="40">',
+				esc_attr( $name . '[' . $i . '][desc]' ),
+				esc_attr( $value[$i]['desc'] )
+			);
+		    printf( '</div>' );
+		}
 	}
 
 }

--- a/classes/class-minnpost-membership-admin.php
+++ b/classes/class-minnpost-membership-admin.php
@@ -198,43 +198,44 @@ class MinnPost_Membership_Admin {
 			}
 			switch ( $page ) {
 				case $this->slug . '-settings':
-					if ( isset( $get_data['method'] ) ) {
-						$method      = sanitize_key( $get_data['method'] );
-						$error_url   = get_admin_url( null, 'admin.php?page=' . $page . '&method=' . $method );
-						$success_url = get_admin_url( null, 'admin.php?page=' . $page );
-
-						if ( isset( $get_data['transient'] ) ) {
-							$transient = sanitize_key( $get_data['transient'] );
-							$posted    = $this->mp_mem_transients->get( $transient );
-						}
-
-						if ( isset( $posted ) && is_array( $posted ) ) {
-							$member_level = $posted;
-							$id           = $member_level['id'];
-						} elseif ( 'edit-member-level' === $method || 'delete-member-level' === $method ) {
-							$id           = $get_data['id'];
-							$member_level = $this->member_levels->get_member_levels( isset( $id ) ? sanitize_key( $id ) : '', true, 'id', true );
-						}
-
-						$benefits = '';
-
-						if ( isset( $member_level ) && is_array( $member_level ) ) {
-							$name                   = $member_level['name'];
-							$is_nonmember           = isset( $member_level['is_nonmember'] ) ? intval( $member_level['is_nonmember'] ) : '';
-							$minimum_monthly_amount = $member_level['minimum_monthly_amount'];
-							$maximum_monthly_amount = $member_level['maximum_monthly_amount'];
-							$starting_value         = $member_level['starting_value'];
-							$benefits               = $member_level['benefits'];
-						}
-
-						if ( 'add-member-level' === $method || 'edit-member-level' === $method ) {
-							require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/member-levels-add-edit.php' );
-						} elseif ( 'delete-member-level' === $method ) {
-							require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/member-levels-delete.php' );
-						}
-					} else {
+					if ( ! isset( $get_data['method'] ) ) {
 						$member_levels = $this->member_levels->get_member_levels();
 						require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/general-settings.php' );
+						break;
+					}
+
+					$method      = sanitize_key( $get_data['method'] );
+					$error_url   = get_admin_url( null, 'admin.php?page=' . $page . '&method=' . $method );
+					$success_url = get_admin_url( null, 'admin.php?page=' . $page );
+
+					if ( isset( $get_data['transient'] ) ) {
+						$transient = sanitize_key( $get_data['transient'] );
+						$posted    = $this->mp_mem_transients->get( $transient );
+					}
+
+					if ( isset( $posted ) && is_array( $posted ) ) {
+						$member_level = $posted;
+						$id           = $member_level['id'];
+					} elseif ( 'edit-member-level' === $method || 'delete-member-level' === $method ) {
+						$id           = $get_data['id'];
+						$member_level = $this->member_levels->get_member_levels( isset( $id ) ? sanitize_key( $id ) : '', true, 'id', true );
+					}
+
+					$benefits = '';
+
+					if ( isset( $member_level ) && is_array( $member_level ) ) {
+						$name                   = $member_level['name'];
+						$is_nonmember           = isset( $member_level['is_nonmember'] ) ? intval( $member_level['is_nonmember'] ) : '';
+						$minimum_monthly_amount = $member_level['minimum_monthly_amount'];
+						$maximum_monthly_amount = $member_level['maximum_monthly_amount'];
+						$starting_value         = $member_level['starting_value'];
+						$benefits               = $member_level['benefits'];
+					}
+
+					if ( 'add-member-level' === $method || 'edit-member-level' === $method ) {
+						require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/member-levels-add-edit.php' );
+					} elseif ( 'delete-member-level' === $method ) {
+						require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/member-levels-delete.php' );
 					}
 					break;
 				case $this->slug . '-benefit-results':

--- a/classes/class-minnpost-membership-admin.php
+++ b/classes/class-minnpost-membership-admin.php
@@ -694,6 +694,20 @@ class MinnPost_Membership_Admin {
 				),
 			);
 
+			$settings[ $this_section . '_summary_compact' ] = array(
+				'title'    => __( 'Summary for smaller screens', 'minnpost-membership' ),
+				'callback' => $callbacks['editor'],
+				'page'     => $this_section,
+				'section'  => $this_section,
+				'args'     => array(
+					'desc'          => '',
+					'constant'      => '',
+					'type'          => 'text',
+					'rows'          => '5',
+					'media_buttons' => false,
+				),
+			);
+
 			$settings[ $this_section . '_pre_form_text' ] = array(
 				'title'    => __( 'Pre form text', 'minnpost-membership' ),
 				'callback' => $callbacks['text'],

--- a/classes/class-minnpost-membership-content-items.php
+++ b/classes/class-minnpost-membership-content-items.php
@@ -52,6 +52,7 @@ class MinnPost_Membership_Content_Items {
 	*
 	*/
 	public function add_actions() {
+		add_action( 'init', array( $this, 'create_thank_you_gift' ), 0 );
 		add_action( 'init', array( $this, 'create_partner' ), 0 );
 		add_action( 'init', array( $this, 'create_partner_offer' ), 0 );
 		add_action( 'admin_menu', array( $this, 'create_sub_menus' ), 20 );
@@ -60,6 +61,58 @@ class MinnPost_Membership_Content_Items {
 		add_action( 'admin_menu', array( $this, 'remove_partner_offer_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'create_partner_offer_fields' ) );
 		add_filter( 'pre_get_posts', array( $this, 'membership_content_default_order' ), 10, 1 );
+	}
+
+	/**
+	* Create the thank-you gift content type
+	*
+	*/
+	public function create_thank_you_gift() {
+		$labels = array(
+			'name'                  => _x( 'Thank-you Gifts', 'Post Type General Name', 'minnpost-membership' ),
+			'singular_name'         => _x( 'Thank-you Gift', 'Post Type Singular Name', 'minnpost-membership' ),
+			'menu_name'             => __( 'Thank-you Gifts', 'minnpost-membership' ),
+			'name_admin_bar'        => __( 'Thank-you Gift', 'minnpost-membership' ),
+			'attributes'            => __( 'Thank-you Gift Attributes', 'minnpost-membership' ),
+			'all_items'             => __( 'All Thank-you Gifts', 'minnpost-membership' ),
+			'add_new_item'          => __( 'Add New Thank-you Gift', 'minnpost-membership' ),
+			'add_new'               => __( 'Add New', 'minnpost-membership' ),
+			'new_item'              => __( 'New Thank-you Gift', 'minnpost-membership' ),
+			'edit_item'             => __( 'Edit Thank-you Gift', 'minnpost-membership' ),
+			'update_item'           => __( 'Update Thank-you Gift', 'minnpost-membership' ),
+			'view_item'             => __( 'View Thank-you Gift', 'minnpost-membership' ),
+			'view_items'            => __( 'View Thank-you Gifts', 'minnpost-membership' ),
+			'search_items'          => __( 'Search Thank-you Gift', 'minnpost-membership' ),
+			'not_found'             => __( 'Not found', 'minnpost-membership' ),
+			'not_found_in_trash'    => __( 'Not found in Trash', 'minnpost-membership' ),
+			'featured_image'        => __( 'Featured Image', 'minnpost-membership' ),
+			'set_featured_image'    => __( 'Set featured image', 'minnpost-membership' ),
+			'remove_featured_image' => __( 'Remove featured image', 'minnpost-membership' ),
+			'use_featured_image'    => __( 'Use as featured image', 'minnpost-membership' ),
+			'insert_into_item'      => __( 'Insert into thank-you gift', 'minnpost-membership' ),
+			'uploaded_to_this_item' => __( 'Uploaded to this thank-you gift', 'minnpost-membership' ),
+			'items_list'            => __( 'Thank-you gifts list', 'minnpost-membership' ),
+			'items_list_navigation' => __( 'Thank-you gifts list navigation', 'minnpost-membership' ),
+			'filter_items_list'     => __( 'Filter thank-you gifts list', 'minnpost-membership' ),
+		);
+		$args   = array(
+			'label'               => __( 'Thank-you gift', 'minnpost-membership' ),
+			'description'         => __( 'Thank-you gifts for members', 'minnpost-membership' ),
+			'labels'              => $labels,
+			'supports'            => array( 'title', 'revisions' ),
+			'hierarchical'        => false,
+			'public'              => true,
+			'show_ui'             => true,
+			'show_in_menu'        => false,
+			'show_in_admin_bar'   => true,
+			'show_in_nav_menus'   => true,
+			'can_export'          => true,
+			'has_archive'         => false,
+			'exclude_from_search' => true,
+			'publicly_queryable'  => true,
+			'capability_type'     => 'page',
+		);
+		register_post_type( 'thank_you_gift', $args );
 	}
 
 	/**
@@ -194,10 +247,12 @@ class MinnPost_Membership_Content_Items {
 	*
 	*/
 	public function create_sub_menus() {
-		$partner    = 'edit.php?post_type=partner';
-		$capability = 'manage_minnpost_membership_options';
+		$capability     = 'manage_minnpost_membership_options';
+		$partner        = 'edit.php?post_type=partner';
 		add_submenu_page( $this->slug, 'Partners', 'Partners', $capability, $partner );
-		$partner_offer = 'edit.php?post_type=partner_offer';
+		$thank_you_gift = 'edit.php?post_type=thank_you_gift';
+		add_submenu_page( $this->slug, 'Thank-you Gifts', 'Thank-you Gifts', $capability, $thank_you_gift );
+		$partner_offer  = 'edit.php?post_type=partner_offer';
 		add_submenu_page( $this->slug, 'Partner Offers', 'Partner Offers', $capability, $partner_offer );
 	}
 

--- a/classes/class-minnpost-membership-content-items.php
+++ b/classes/class-minnpost-membership-content-items.php
@@ -57,6 +57,7 @@ class MinnPost_Membership_Content_Items {
 		add_action( 'init', array( $this, 'create_partner_offer' ), 0 );
 		add_action( 'admin_menu', array( $this, 'create_sub_menus' ), 20 );
 		add_filter( 'enter_title_here', array( $this, 'title_placeholders' ), 10, 1 );
+		add_action( 'cmb2_init', array( $this, 'create_thank_you_gift_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'create_partner_fields' ) );
 		add_action( 'admin_menu', array( $this, 'remove_partner_offer_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'create_partner_offer_fields' ) );
@@ -248,10 +249,10 @@ class MinnPost_Membership_Content_Items {
 	*/
 	public function create_sub_menus() {
 		$capability     = 'manage_minnpost_membership_options';
-		$partner        = 'edit.php?post_type=partner';
-		add_submenu_page( $this->slug, 'Partners', 'Partners', $capability, $partner );
 		$thank_you_gift = 'edit.php?post_type=thank_you_gift';
 		add_submenu_page( $this->slug, 'Thank-you Gifts', 'Thank-you Gifts', $capability, $thank_you_gift );
+		$partner        = 'edit.php?post_type=partner';
+		add_submenu_page( $this->slug, 'Partners', 'Partners', $capability, $partner );
 		$partner_offer  = 'edit.php?post_type=partner_offer';
 		add_submenu_page( $this->slug, 'Partner Offers', 'Partner Offers', $capability, $partner_offer );
 	}
@@ -272,6 +273,36 @@ class MinnPost_Membership_Content_Items {
 			$title = __( 'Enter offer/event name here', 'minnpost-membership' );
 		}
 		return $title;
+	}
+
+	/**
+	* Create the thank-you gift fields with CMB2
+	*
+	*/
+	public function create_thank_you_gift_fields() {
+		$object_type = 'thank_you_gift';
+		$prefix      = '_mp_thank_you_gift_';
+
+		$thank_you_gift_fields = new_cmb2_box(
+			array(
+				'id' => $prefix . 'thank_you_gift_fields',
+				'title' => __( 'Gift Details' ),
+				'object_types' => $object_type,
+			)
+		);
+		$thank_you_gift_fields->add_field(
+			array(
+				'id'   => $prefix . 'image',
+				'name' => __( 'Image', 'minnpost-membership' ),
+				'desc'         => __( 'Upload an image or enter an URL.', 'minnpost-membership' ),
+				'type' => 'file',
+				'preview_size' => array( 130, 85 ),
+				// query_args are passed to wp.media's library query.
+					'query_args'   => array(
+					'type' => 'image',
+				),
+			)
+		);
 	}
 
 	/**

--- a/classes/class-minnpost-membership-content-items.php
+++ b/classes/class-minnpost-membership-content-items.php
@@ -283,24 +283,59 @@ class MinnPost_Membership_Content_Items {
 		$object_type = 'thank_you_gift';
 		$prefix      = '_mp_thank_you_gift_';
 
+		$member_level_options = $this->member_levels->get_member_levels();
+		array_walk( $member_level_options, function(&$level) {
+			$level = $level['name'];
+		});
+
 		$thank_you_gift_fields = new_cmb2_box(
 			array(
-				'id' => $prefix . 'thank_you_gift_fields',
-				'title' => __( 'Gift Details' ),
+				'id'           => $prefix . 'thank_you_gift_fields',
+				'title'        => __( 'Gift Details' ),
 				'object_types' => $object_type,
 			)
 		);
 		$thank_you_gift_fields->add_field(
 			array(
-				'id'   => $prefix . 'image',
-				'name' => __( 'Image', 'minnpost-membership' ),
+				'id'   => $prefix . 'description',
+				'name' => __( 'Description', 'minnpost-membership' ),
+				'type' => 'text',
+				'desc' => __( 'Enter a short description of the gift.', 'minnpost-membership' )
+			)
+		);
+		$thank_you_gift_fields->add_field(
+			array(
+				'id'           => $prefix . 'image',
+				'name'         => __( 'Image', 'minnpost-membership' ),
 				'desc'         => __( 'Upload an image or enter an URL.', 'minnpost-membership' ),
-				'type' => 'file',
+				'type'         => 'file',
 				'preview_size' => array( 130, 85 ),
 				// query_args are passed to wp.media's library query.
-					'query_args'   => array(
+				'query_args'   => array(
 					'type' => 'image',
 				),
+			)
+		);
+		$thank_you_gift_fields->add_field(
+			array(
+				'id'               => $prefix . 'type',
+				'type'             => 'radio_inline',
+				'name'             => __( 'Type', 'minnpost-membership' ),
+				'desc'             => __( 'Users can choose only one piece of swag; subscriptions are multi-select.', 'minnpost-membership' ),
+				'options'          => array(
+					'swag'         => __( 'Swag', 'minnpost-membership' ),
+					'subscription' => __( 'Subscription', 'minnpost-membership' )
+				),
+				'default'          => 'swag'
+			)
+		);
+		$thank_you_gift_fields->add_field(
+			array(
+				'id'   		=> $prefix . 'minimum_member_level_id',
+				'type' 		=> 'select',
+				'name' 		=> __( 'Minimum member level', 'minnpost-membership' ),
+				'desc' 		=> '',
+				'options' => $member_level_options
 			)
 		);
 	}

--- a/templates/admin/member-levels-add-edit.php
+++ b/templates/admin/member-levels-add-edit.php
@@ -16,47 +16,76 @@
 	<input type="hidden" name="id" value="<?php echo absint( $id ); ?>" />
 	<?php } ?>
 
-	<div class="minnpost-member-level-name">
-		<label for="name"><?php echo esc_html__( 'Name', 'minnpost-membership' ); ?>: </label>
-		<input type="text" id="name" name="name" required value="<?php echo isset( $name ) ? esc_html( $name ) : ''; ?>" />
-	</div>
+	<table class="form-table">
+		<tbody>
+			<tr class="minnpost-member-level-name">
+				<th scope="row">
+					<label for="name"><?php echo esc_html__( 'Name', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<input type="text" id="name" name="name" required value="<?php echo isset( $name ) ? esc_html( $name ) : ''; ?>" />
+				</td>
+			</tr>
 
-	<div class="minnpost-member-level-is-nonmember">
-		<label for="is-nonmember"><?php echo esc_html__( 'Non-member level?', 'minnpost-membership' ); ?>: </label>
-		<?php
-		if ( isset( $is_nonmember ) && 1 === $is_nonmember ) {
-			$checked = ' checked';
-		} else {
-			$checked = '';
-		}
-		?>
-		<input type="checkbox" id="is-nonmember" name="is_nonmember" value="1"<?php echo $checked; ?> />
-	</div>
+			<tr class="minnpost-member-level-is-nonmember">
+				<th scope="row">
+					<label for="is-nonmember"><?php echo esc_html__( 'Non-member level?', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<?php
+					if ( isset( $is_nonmember ) && 1 === $is_nonmember ) {
+						$checked = ' checked';
+					} else {
+						$checked = '';
+					}
+					?>
+					<input type="checkbox" id="is-nonmember" name="is_nonmember" value="1"<?php echo $checked; ?> />
+				</td>
+			</tr>
 
-	<div class="minnpost-member-level-minimum-amount">
-		<label for="minimum-amount"><?php echo esc_html__( 'Minimum monthly amount', 'minnpost-membership' ); ?>: </label>
-		<input type="tel" id="minimum-amount" name="minimum_monthly_amount" value="<?php echo isset( $minimum_monthly_amount ) ? esc_attr( $minimum_monthly_amount ) : ''; ?>" />
-	</div>
+			<tr class="minnpost-member-level-minimum-amount">
+				<th scope="row">
+					<label for="minimum-amount"><?php echo esc_html__( 'Minimum monthly amount', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<input type="tel" id="minimum-amount" name="minimum_monthly_amount" value="<?php echo isset( $minimum_monthly_amount ) ? esc_attr( $minimum_monthly_amount ) : ''; ?>" />
+				</td>
+			</tr>
 
-	<div class="minnpost-member-level-maximum-amount">
-		<label for="maximum-amount"><?php echo esc_html__( 'Maximum monthly amount', 'minnpost-membership' ); ?>: </label>
-		<input type="tel" id="maximum-amount" name="maximum_monthly_amount" value="<?php echo isset( $maximum_monthly_amount ) ? esc_attr( $maximum_monthly_amount ) : ''; ?>" />
-	</div>
+			<tr class="minnpost-member-level-maximum-amount">
+				<th scope="row">
+					<label for="maximum-amount"><?php echo esc_html__( 'Maximum monthly amount', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<input type="tel" id="maximum-amount" name="maximum_monthly_amount" value="<?php echo isset( $maximum_monthly_amount ) ? esc_attr( $maximum_monthly_amount ) : ''; ?>" />
+				</td>
+			</tr>
 
-	<div class="minnpost-member-level-starting-value">
-		<label for="starting-value"><?php echo esc_html__( 'Starting monthly value', 'minnpost-membership' ); ?>: </label>
-		<input type="tel" id="starting-value" name="starting_value" value="<?php echo isset( $starting_value ) ? esc_attr( $starting_value ) : ''; ?>" />
-	</div>
+			<tr class="minnpost-member-level-starting-value">
+				<th scope="row">
+					<label for="starting-value"><?php echo esc_html__( 'Starting monthly value', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<input type="tel" id="starting-value" name="starting_value" value="<?php echo isset( $starting_value ) ? esc_attr( $starting_value ) : ''; ?>" />
+				</td>
+			</tr>
 
-	<div class="minnpost-member-level-benefits">
-		<label for="benefits"><?php echo esc_html__( 'Benefits', 'minnpost-membership' ); ?>: </label>
-		<?php
-		$settings = array(
-			'media_buttons' => false,
-		);
-		wp_editor( $benefits, 'benefits', $settings );
-		?>
-	</div>
+			<tr class="minnpost-member-level-benefits">
+				<th scope="row">
+					<label for="benefits"><?php echo esc_html__( 'Benefits', 'minnpost-membership' ); ?>: </label>
+				</th>
+				<td>
+					<?php
+					$settings = array(
+						'media_buttons' => false,
+					);
+					wp_editor( $benefits, 'benefits', $settings );
+					?>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
 	<?php
 		submit_button(
 			// translators: the placeholder refers to the currently selected method (add, edit, or clone)


### PR DESCRIPTION
Added admin settings for various parts of the new donation landing page, including:

* A short blurb (for smaller screens) to go at the top
* Suggested monthly, yearly, & one-time amounts
* Thank-you gifts (a new custom post type)

The suggested amounts settings are structured slightly differently here than the frontend expects in the integration-donation-flow-changes branch — namely, they're saved in separate options in the `wp_options` table instead of a single multi-dimensional array. Was wondering if you had any suggestions for a better way to align the structure @jonathanstegall?

Note: This branch is targeted to `master` so that it can be merged and deployed before the frontend changes, without disrupting the existing flow.